### PR TITLE
Add neumorphic homepage component

### DIFF
--- a/src/pages/NeumorphicHome.css
+++ b/src/pages/NeumorphicHome.css
@@ -1,0 +1,102 @@
+@import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@400;700&display=swap');
+
+.neo-home {
+  background: #e0e5ec;
+  min-height: 100vh;
+  padding: 2rem;
+  font-family: 'Quicksand', sans-serif;
+  color: #333;
+}
+
+.neo-header {
+  text-align: center;
+  padding: 4rem 1rem;
+  margin-bottom: 3rem;
+  border-radius: 1.5rem;
+  background: #e0e5ec;
+  box-shadow: 8px 8px 16px #babecc, -8px -8px 16px #ffffff;
+}
+
+.neo-header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.neo-header .subtitle {
+  font-size: 1.25rem;
+  color: #555;
+}
+
+.welcome-card {
+  max-width: 500px;
+  margin: 0 auto 3rem;
+  padding: 2rem;
+  text-align: center;
+  border-radius: 1.5rem;
+  background: #e0e5ec;
+  box-shadow: inset 4px 4px 8px #babecc, inset -4px -4px 8px #ffffff;
+}
+
+.neo-button {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  border: none;
+  background: #e0e5ec;
+  border-radius: 1rem;
+  box-shadow: 4px 4px 8px #babecc, -4px -4px 8px #ffffff;
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+}
+
+.neo-button:hover {
+  box-shadow: 6px 6px 12px #babecc, -6px -6px 12px #ffffff;
+}
+
+.neo-button:active {
+  box-shadow: inset 4px 4px 8px #babecc, inset -4px -4px 8px #ffffff;
+}
+
+.features-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-bottom: 4rem;
+}
+
+.feature-card {
+  flex: 1 0 140px;
+  padding: 1.5rem;
+  text-align: center;
+  border-radius: 1rem;
+  background: #e0e5ec;
+  box-shadow: 4px 4px 8px #babecc, -4px -4px 8px #ffffff;
+  transition: box-shadow 0.2s;
+}
+
+.feature-card:hover {
+  box-shadow: 6px 6px 12px #babecc, -6px -6px 12px #ffffff;
+}
+
+.neo-nav {
+  display: flex;
+  justify-content: space-around;
+  padding: 1rem;
+  margin-top: 2rem;
+  border-radius: 1.5rem;
+  background: #e0e5ec;
+  box-shadow: 8px 8px 16px #babecc, -8px -8px 16px #ffffff;
+}
+
+.neo-nav a {
+  color: #333;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  transition: color 0.2s;
+}
+
+.neo-nav a:hover {
+  color: #000;
+}

--- a/src/pages/NeumorphicHome.tsx
+++ b/src/pages/NeumorphicHome.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import './NeumorphicHome.css';
+
+const NeumorphicHome: React.FC = () => {
+  return (
+    <div className="neo-home">
+      <header className="neo-header">
+        <h1>SemperMade</h1>
+        <p className="subtitle">Modern Neumorphic Design</p>
+      </header>
+
+      <section className="welcome-card">
+        <h2>Welcome!</h2>
+        <p>Experience a soft and tactile interface crafted with modern neumorphism.</p>
+        <button className="neo-button">Get Started</button>
+      </section>
+
+      <div className="features-row">
+        <div className="feature-card">
+          <span role="img" aria-label="speed">⚡</span>
+          <p>Fast</p>
+        </div>
+        <div className="feature-card">
+          <span role="img" aria-label="secure">🔒</span>
+          <p>Secure</p>
+        </div>
+        <div className="feature-card">
+          <span role="img" aria-label="responsive">📱</span>
+          <p>Responsive</p>
+        </div>
+      </div>
+
+      <nav className="neo-nav">
+        <a href="#home">Home</a>
+        <a href="#features">Features</a>
+        <a href="#contact">Contact</a>
+      </nav>
+    </div>
+  );
+};
+
+export default NeumorphicHome;


### PR DESCRIPTION
## Summary
- add `NeumorphicHome` page implementing a neumorphic style homepage
- provide CSS for shadows, hover effects and Quicksand font

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_6869b4ae56bc832fb8bd0d3f88cbf14a