### PR TITLE
Add Terms and Privacy pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Terms from "./pages/Terms";
+import Privacy from "./pages/Privacy";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +18,8 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/terms" element={<Terms />} />
+          <Route path="/privacy" element={<Privacy />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,11 +1,20 @@
 import { Button } from "@/components/ui/button";
 import { Menu, X } from "lucide-react";
 import { useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 
 const Navigation = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const scrollToSection = (sectionId: string) => {
+    if (location.pathname !== '/') {
+      navigate('/#' + sectionId);
+      setIsMenuOpen(false);
+      return;
+    }
+
     const element = document.getElementById(sectionId);
     if (element) {
       const navHeight = 64; // Height of fixed navbar

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,8 +3,24 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Check, CircleDollarSign, Users, FileText } from "lucide-react";
 import Navigation from "@/components/Navigation";
+import { Link, useLocation } from "react-router-dom";
+import { useEffect } from "react";
 
 const Index = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.hash) {
+      const id = location.hash.replace('#', '');
+      const element = document.getElementById(id);
+      if (element) {
+        const navHeight = 64;
+        const elementPosition = element.offsetTop - navHeight;
+        window.scrollTo({ top: elementPosition, behavior: 'smooth' });
+      }
+    }
+  }, [location]);
+
   return (
     <div className="min-h-screen bg-background">
       <Navigation />
@@ -412,8 +428,8 @@ const Index = () => {
             <p className="text-muted-foreground">Unlimited development services for a flat monthly fee</p>
           </div>
           <div className="flex flex-wrap justify-center gap-8 text-sm text-muted-foreground">
-            <a href="#" className="hover:text-primary transition-colors">Terms of Service</a>
-            <a href="#" className="hover:text-primary transition-colors">Privacy Policy</a>
+            <Link to="/terms" className="hover:text-primary transition-colors">Terms of Service</Link>
+            <Link to="/privacy" className="hover:text-primary transition-colors">Privacy Policy</Link>
             <a href="#" className="hover:text-primary transition-colors">Contact</a>
             <a href="#" className="hover:text-primary transition-colors">Support</a>
           </div>

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,29 @@
+import Navigation from "@/components/Navigation";
+
+const Privacy = () => (
+  <div className="min-h-screen bg-background">
+    <Navigation />
+    <section className="pt-24 pb-16 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-4xl font-bold mb-6 text-center">Privacy Policy</h1>
+        <p>This Privacy Policy explains how semperMade collects and uses information when you interact with our website or services.</p>
+        <h2 className="text-2xl font-semibold">1. Information We Collect</h2>
+        <p>We may collect your name, email address, and any other information you choose to provide when contacting us or subscribing to our services.</p>
+        <h2 className="text-2xl font-semibold">2. How We Use Information</h2>
+        <p>Your information is used to provide and improve our services, respond to inquiries, and communicate with you about your subscription.</p>
+        <h2 className="text-2xl font-semibold">3. Sharing of Information</h2>
+        <p>We do not sell your personal data. Information may be shared with trusted service providers solely to operate our business and only as necessary.</p>
+        <h2 className="text-2xl font-semibold">4. Security</h2>
+        <p>We take reasonable measures to protect your information, but no method of transmission over the Internet is completely secure.</p>
+        <h2 className="text-2xl font-semibold">5. Your Rights</h2>
+        <p>You may request access to or deletion of your personal data by contacting us. We will comply with applicable laws.</p>
+        <h2 className="text-2xl font-semibold">6. Changes to This Policy</h2>
+        <p>We may update this Privacy Policy from time to time. Continued use of the service after changes means you accept the updated policy.</p>
+        <h2 className="text-2xl font-semibold">7. Contact</h2>
+        <p>If you have questions about this Privacy Policy, please email support@sempermade.com.</p>
+      </div>
+    </section>
+  </div>
+);
+
+export default Privacy;

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,29 @@
+import Navigation from "@/components/Navigation";
+
+const Terms = () => (
+  <div className="min-h-screen bg-background">
+    <Navigation />
+    <section className="pt-24 pb-16 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-4xl font-bold mb-6 text-center">Terms of Service</h1>
+        <p>By accessing or using the semperMade website and services, you agree to be bound by these Terms of Service. If you do not agree, please do not use our services.</p>
+        <h2 className="text-2xl font-semibold">1. Services</h2>
+        <p>semperMade offers subscription based development services including unlimited bug fixes, CI/CD setup and improvements, and test coverage enhancement. Services are delivered through your connected repositories via pull requests.</p>
+        <h2 className="text-2xl font-semibold">2. Subscriptions & Payments</h2>
+        <p>All plans are billed monthly for a flat fee as listed on our pricing page. You may pause or cancel your subscription at any time, and service will continue until the end of your current billing period.</p>
+        <h2 className="text-2xl font-semibold">3. Acceptable Use</h2>
+        <p>You agree not to use our services for any unlawful or abusive purpose. We reserve the right to refuse work that violates these terms.</p>
+        <h2 className="text-2xl font-semibold">4. Intellectual Property</h2>
+        <p>All code we contribute remains your property. We may display your name or logo as a customer unless you request otherwise.</p>
+        <h2 className="text-2xl font-semibold">5. Disclaimer</h2>
+        <p>While we strive to deliver high quality work, our services are provided "as is" without warranties of any kind. semperMade is not liable for any indirect or consequential damages.</p>
+        <h2 className="text-2xl font-semibold">6. Changes to These Terms</h2>
+        <p>We may update these Terms from time to time. Continued use of the service after changes constitutes acceptance of the new Terms.</p>
+        <h2 className="text-2xl font-semibold">7. Contact</h2>
+        <p>For questions about these Terms, please contact us at support@sempermade.com.</p>
+      </div>
+    </section>
+  </div>
+);
+
+export default Terms;


### PR DESCRIPTION
## Summary
- create Terms of Service and Privacy Policy pages
- connect footer links to new pages
- keep navigation working across pages
- add routing for new pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c8f2dd94832f837f0dbdb1c9a2d8